### PR TITLE
Change menus to line up with designs.

### DIFF
--- a/src/routes/questiontree/TopBar.js
+++ b/src/routes/questiontree/TopBar.js
@@ -2,6 +2,7 @@ import React from 'react'
 import {Image, StyleSheet, Text, TouchableNativeFeedback, View} from 'react-native'
 import images from '../../assets/images'
 import {largerFontSize, largerLineheight} from '../../assets/styles'
+import { standardMargin } from './../../assets/styles';
 
 export default class TopBar extends React.PureComponent {
   render () {
@@ -30,6 +31,7 @@ const styles = StyleSheet.create({
   },
   topBar: {
     height: 35,
+    marginTop: standardMargin,
     flexDirection: 'row',
     justifyContent: 'flex-start'
   },

--- a/src/routes/questiontree/TouchableListItem.js
+++ b/src/routes/questiontree/TouchableListItem.js
@@ -3,6 +3,7 @@ import {Image, StyleSheet, TouchableNativeFeedback, View} from 'react-native'
 import LargeText from '../../components/LargeText'
 import images from '../../assets/images'
 import colors from '../../assets/colors'
+import { standardMargin } from './../../assets/styles';
 
 export default class TouchableListItem extends React.PureComponent {
   onTouch = () => this.props.onTouch(this.props.name)
@@ -26,7 +27,10 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     padding: 5,
     paddingTop: 0,
+    marginTop: standardMargin,
+    marginBottom: standardMargin,
     borderBottomWidth: 1,
+    borderTopWidth: 1,
     borderColor: colors.black,
   },
   chevron: {


### PR DESCRIPTION
I did some modifications to the styling to fix some issues with styling and correlation with the design.

Here is the list of menus I considered when I went through the app. (Items marked with an X have been changed by me)

   - Landing page - I think the styling looks fine for now. It already matches pretty close to design, but the camera icon on there is off center.

   - Auto-detect item - For the intro, I think keeping it on one page will make it easier for the user to read through and understand without thinking it's too much. For results though, I haven't seen that page yet, so I'm not sure what it looks like.

X - Question tree - This is currently the only menu that I changed. The changes I made make the navigation look a little nicer and closer to design.

   - Search - It's temporary and may not exist on demo day.

   - That list item thingy on the navbar - I don't know what that's supposed to be.

If there's anything else I should consider, let me know!